### PR TITLE
Example launch files for dockerized watchdog & processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Set temporary image for building
+FROM ros:foxy as intermediate
+# Add metadata identifying these images as build containers
+# After build, remove intermediate images with `docker rmi -f $(docker images -q --filter label=stage=intermediate)`
+LABEL stage=intermediate
+
+# Clone and build repository
+WORKDIR /root
+RUN git clone https://github.com/ros-safety/software_watchdogs.git
+RUN . /opt/ros/foxy/setup.sh && \
+    colcon build
+
+# Choose the base image for the final image
+FROM ros:foxy-ros-core
+
+# Install dependencies for demo applications
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+   && apt-get -y install --no-install-recommends ros-foxy-demo-nodes-cpp \
+   #
+   # Clean up
+   && apt-get autoremove -y \
+   && apt-get clean -y \
+   && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=dialog
+
+# Copy across the files from our `intermediate` container
+RUN mkdir -p /root/install
+COPY --from=intermediate /root/install /root/install
+
+# Set up auto-source of workspace
+RUN sed --in-place --expression \
+      '$isource "/root/install/setup.bash"' \
+      /ros_entrypoint.sh

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -28,8 +28,8 @@ from launch.event_handlers.on_shutdown import OnShutdown
 
 # Hack to cleanly exit all roslaunch group processes (docker init is GID 1)
 def group_stop(context, *args, **kwargs):
-    print(os.getpgid(os.getpid()))
-    subprocess.call(['kill', '-INT', '--', str(os.getpgid(os.getpid()))])
+    gid = os.getpgid(os.getpid())
+    subprocess.call(['kill', '-INT', '--', f"-{gid}"])
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
                     package='sw_watchdog',
                     node_plugin='sw_watchdog::SimpleHeartbeat',
                     node_name='heartbeat',
-                    parameters=[{'period': 200}]),
+                    parameters=[{'period': 200}],
                     extra_arguments=[{'use_intra_process_comms': True}]),
             ],
             output='screen',

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
             node_name='my_container',
-            node_namespace='my_namespace',
+            node_namespace='',
             package='rclcpp_components',
             node_executable='component_container',
             composable_node_descriptions=[

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -15,8 +15,12 @@
 """Launch a talker and a heartbeat in a component container."""
 
 import launch
+from launch.actions import EmitEvent
+from launch.actions import LogInfo
+from launch.actions import RegisterEventHandler
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
+from launch.event_handlers.on_shutdown import OnShutdown
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():
@@ -41,4 +45,19 @@ def generate_launch_description():
             output='screen',
     )
 
-    return launch.LaunchDescription([container])
+    # Shutdown event
+    shutdown_event = EmitEvent( event=launch.events.Shutdown() )
+
+    # When Shutdown is requested, clean up docker
+    shutdown_handler = RegisterEventHandler(
+        OnShutdown(
+            on_shutdown = [
+                # Log
+                LogInfo( msg = "Launch was asked to shutdown." ),
+                # Clean up
+                shutdown_event
+            ],
+        )
+    )
+
+    return launch.LaunchDescription([container, shutdown_handler])

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -27,7 +27,7 @@ from launch.event_handlers.on_shutdown import OnShutdown
 
 # Stop all group processes
 def group_stop(context, *args, **kwargs):
-    subprocess.call(['kill', '--INT', '-1'])
+    subprocess.call(['kill', '-INT', '--', '-1'])
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -38,8 +38,7 @@ def generate_launch_description():
                     parameters=[{'period': 200}],
                     extra_arguments=[{'use_intra_process_comms': True}]),
             ],
-            output='screen',
-            on_exit=launch.actions.Shutdown()
+            output='screen'
     )
 
     return launch.LaunchDescription([container])

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -36,6 +36,7 @@ def generate_launch_description():
                     node_plugin='sw_watchdog::SimpleHeartbeat',
                     node_name='heartbeat',
                     parameters=[{'period': 200}]),
+                    extra_arguments=[{'use_intra_process_comms': True}]),
             ],
             output='screen',
     )

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -27,7 +27,7 @@ from launch.event_handlers.on_shutdown import OnShutdown
 
 # Stop all group processes
 def group_stop(context, *args, **kwargs):
-    subprocess.call(['kill', '--INT', '--', '-1'])
+    subprocess.call(['kill', '--INT', '-1'])
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -15,6 +15,7 @@
 """Launch a talker and a heartbeat in a component container."""
 
 import subprocess
+import os
 
 import launch
 from launch.actions import EmitEvent
@@ -27,14 +28,14 @@ from launch.event_handlers.on_shutdown import OnShutdown
 
 # Hack to cleanly exit all roslaunch group processes (docker init is GID 1)
 def group_stop(context, *args, **kwargs):
-    subprocess.call(['kill', '-INT', '--', '-1'])
+    subprocess.call(['kill', '-INT', '--', str(os.getpgid(os.getpid()))]
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
             node_name='my_container',
-            node_namespace='',
+            node_namespace='my_namespace',
             package='rclcpp_components',
             node_executable='component_container',
             composable_node_descriptions=[

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -18,9 +18,14 @@ import launch
 from launch.actions import EmitEvent
 from launch.actions import LogInfo
 from launch.actions import RegisterEventHandler
+from launch.actions import OpaqueFunction
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch.event_handlers.on_shutdown import OnShutdown
+
+# Stop all group processes
+def group_stop(context, *args, **kwargs):
+    subprocess.call(['kill', '--INT', '--', '-1'])
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():
@@ -45,9 +50,6 @@ def generate_launch_description():
             output='screen'
     )
 
-    # Shutdown event
-    shutdown_event = EmitEvent( event = launch.events.Shutdown() )
-
     # When Shutdown is requested (launch), clean up all child processes
     shutdown_handler = RegisterEventHandler(
         OnShutdown(
@@ -55,10 +57,9 @@ def generate_launch_description():
                 # Log
                 LogInfo( msg = "heartbeat_composition was asked to shutdown." ),
                 # Clean up
-                shutdown_event
+                OpaqueFunction(function=group_stop),
             ],
         )
     )
-
 
     return launch.LaunchDescription([container, shutdown_handler])

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -28,14 +28,14 @@ from launch.event_handlers.on_shutdown import OnShutdown
 
 # Hack to cleanly exit all roslaunch group processes (docker init is GID 1)
 def group_stop(context, *args, **kwargs):
-    subprocess.call(['kill', '-INT', '--', str(os.getpgid(os.getpid()))]
+    subprocess.call(['kill', '-INT', '--', str(os.getpgid(os.getpid()))])
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
             node_name='my_container',
-            node_namespace='',
+            node_namespace='my_namespace',
             package='rclcpp_components',
             node_executable='component_container',
             composable_node_descriptions=[

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -25,7 +25,7 @@ from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch.event_handlers.on_shutdown import OnShutdown
 
-# Stop all group processes
+# Hack to cleanly exit all group processes with GID 1 (docker init process)
 def group_stop(context, *args, **kwargs):
     subprocess.call(['kill', '-INT', '--', '-1'])
 

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -25,7 +25,7 @@ from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch.event_handlers.on_shutdown import OnShutdown
 
-# Hack to cleanly exit all group processes with GID 1 (docker init process)
+# Hack to cleanly exit all roslaunch group processes (docker init is GID 1)
 def group_stop(context, *args, **kwargs):
     subprocess.call(['kill', '-INT', '--', '-1'])
 

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -15,12 +15,8 @@
 """Launch a talker and a heartbeat in a component container."""
 
 import launch
-from launch.actions import EmitEvent
-from launch.actions import LogInfo
-from launch.actions import RegisterEventHandler
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
-from launch.event_handlers.on_shutdown import OnShutdown
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)
 def generate_launch_description():
@@ -43,21 +39,7 @@ def generate_launch_description():
                     extra_arguments=[{'use_intra_process_comms': True}]),
             ],
             output='screen',
+            on_exit=launch.actions.Shutdown()
     )
 
-    # Shutdown event
-    shutdown_event = EmitEvent( event=launch.events.Shutdown() )
-
-    # When Shutdown is requested, clean up docker
-    shutdown_handler = RegisterEventHandler(
-        OnShutdown(
-            on_shutdown = [
-                # Log
-                LogInfo( msg = "Launch was asked to shutdown." ),
-                # Clean up
-                shutdown_event
-            ],
-        )
-    )
-
-    return launch.LaunchDescription([container, shutdown_handler])
+    return launch.LaunchDescription([container])

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -35,8 +35,7 @@ def generate_launch_description():
                     package='sw_watchdog',
                     node_plugin='sw_watchdog::SimpleHeartbeat',
                     node_name='heartbeat',
-                    parameters=[{'period': 200}],
-                    extra_arguments=[{'use_intra_process_comms': True}]),
+                    parameters=[{'period': 200}]),
             ],
             output='screen',
     )

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -14,6 +14,8 @@
 
 """Launch a talker and a heartbeat in a component container."""
 
+import subprocess
+
 import launch
 from launch.actions import EmitEvent
 from launch.actions import LogInfo

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -28,6 +28,7 @@ from launch.event_handlers.on_shutdown import OnShutdown
 
 # Hack to cleanly exit all roslaunch group processes (docker init is GID 1)
 def group_stop(context, *args, **kwargs):
+    print(os.getpgid(os.getpid()))
     subprocess.call(['kill', '-INT', '--', str(os.getpgid(os.getpid()))])
 
 # Note: syntax has changed in foxy (removal of 'node_' prefixes)

--- a/launch/heartbeat_composition.launch.py
+++ b/launch/heartbeat_composition.launch.py
@@ -38,7 +38,8 @@ def generate_launch_description():
                     parameters=[{'period': 200}],
                     extra_arguments=[{'use_intra_process_comms': True}]),
             ],
-            output='screen'
+            output='screen',
+            on_exit=launch.actions.Shutdown()
     )
 
     return launch.LaunchDescription([container])

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -33,7 +33,7 @@ def generate_launch_description():
 
     # Start monitored entity once (via docker)
     docker_run_cmd = launch.actions.ExecuteProcess(
-        cmd=['docker', 'run', '-d', '--name', 'talker', '-v', '/var/run/docker.sock:/var/run/docker.sock', '-v', '/usr/bin/docker:/usr/bin/docker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'],
+        cmd=['docker', 'run', '-d', '--name', 'talker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'],
         #output='screen'
     )
 
@@ -81,10 +81,10 @@ def generate_launch_description():
             entities = [
                 # Log
                 LogInfo( msg = "Watchdog transitioned to 'INACTIVE' state." ),
-                # Restart the monitored entity
-                docker_restart_cmd,
                 # Change state event (inactive -> active)
                 watchdog_activate_trans_event,
+                # Restart the monitored entity
+                docker_restart_cmd,
             ],
         )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -35,11 +35,13 @@ def docker_run(context, *args, **kwargs):
 
 # Stop docker container
 def docker_stop(context, *args, **kwargs):
-    subprocess.call(['docker', 'stop', 'talker'])
+    subprocess.call(['docker', 'kill', '--signal=SIGINT', 'talker'])
+    #subprocess.call(['docker', 'stop', 'talker'])
 
 # Restart docker container
 def docker_restart(context, *args, **kwargs):
     docker_stop(None)
+    time.wait(1)
     docker_run(None)
 
 
@@ -94,7 +96,7 @@ def generate_launch_description():
         OnShutdown(
             on_shutdown = [
                 # Log
-                LogInfo( msg = "Launch was asked to shutdown." ),
+                LogInfo( msg = "watchdog_in_docker was asked to shutdown." ),
                 # Clean up docker
                 OpaqueFunction(function=docker_stop),
             ],

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -29,11 +29,11 @@ from launch.event_handlers.on_shutdown import OnShutdown
 import lifecycle_msgs.msg
 
 # Start monitored entity
-def docker_run():
+def docker_run(context, *args, **kwargs):
     subprocess.call(['docker', 'run', '-d', '--rm', '--name', 'talker', '-v', '/var/run/docker.sock:/var/run/docker.sock', '-v', '/usr/bin/docker:/usr/bin/docker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'])
 
 # Stop docker container
-def docker_stop():
+def docker_stop(context, *args, **kwargs):
     subprocess.call(['docker', 'stop', 'talker'])
 
 

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -40,6 +40,7 @@ def docker_stop(context, *args, **kwargs):
 # Restart docker container
 def docker_restart(context, *args, **kwargs):
     docker_stop(None)
+    time.sleep(1)
     docker_run(None)
 
 

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -39,7 +39,7 @@ def generate_launch_description():
 
     # Restart monitored entity upon watchdog miss (via docker)
     docker_restart_cmd = launch.actions.ExecuteProcess(
-        cmd=['docker', 'restart', 'talker']
+        cmd=['docker', 'start', 'talker']
         #output='screen'
     )
 

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -106,9 +106,9 @@ def generate_launch_description():
     # Add the actions to the launch description.
     # The order they are added reflects the order in which they will be executed
     ld.add_action( set_tty_launch_config_action )
-    ld.add_action( docker_run_cmd )
+    #ld.add_action( docker_run_cmd )
     ld.add_action( watchdog_node )
     ld.add_action( watchdog_inactive_handler )
-    ld.add_action( shutdown_handler )
+    #ld.add_action( shutdown_handler )
 
     return ld

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -71,11 +71,12 @@ def generate_launch_description():
          )
     )
 
-    # When the watchdog reaches the 'inactive' state, log a message
+    # When the watchdog reaches the 'inactive' state from 'active', log message
     # and restart monitored entity (via docker)
     watchdog_inactive_handler = RegisterEventHandler(
         OnStateTransition(
             target_lifecycle_node = watchdog_node,
+            start_state = 'deactivating',
             goal_state = 'inactive',
             entities = [
                 # Log

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -39,7 +39,7 @@ def generate_launch_description():
 
     # Restart monitored entity upon watchdog miss (via docker)
     docker_restart_cmd = launch.actions.ExecuteProcess(
-        cmd=['docker', 'start', 'talker']
+        cmd=['docker', 'restart', 'talker']
         #output='screen'
     )
 
@@ -81,10 +81,10 @@ def generate_launch_description():
             entities = [
                 # Log
                 LogInfo( msg = "Watchdog transitioned to 'INACTIVE' state." ),
-                # Change state event (inactive -> active)
-                watchdog_activate_trans_event,
                 # Restart the monitored entity
                 docker_restart_cmd,
+                # Change state event (inactive -> active)
+                watchdog_activate_trans_event,
             ],
         )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -38,10 +38,10 @@ def generate_launch_description():
     )
 
     # Restart monitored entity upon watchdog miss (via docker)
-    # docker_restart_cmd = launch.actions.ExecuteProcess(
-    #     cmd=['docker', 'restart', 'talker']
-    #     #output='screen'
-    # )
+    docker_restart_cmd = launch.actions.ExecuteProcess(
+        cmd=['docker', 'restart', 'talker']
+        #output='screen'
+    )
 
     # Remove docker container
     docker_rm_cmd = launch.actions.ExecuteProcess(
@@ -84,9 +84,9 @@ def generate_launch_description():
                 # Change state event (inactive -> active)
                 watchdog_activate_trans_event,
                 # Restart the monitored entity
-                launch.actions.ExecuteProcess(
-                    cmd=['docker', 'restart', 'talker']
-                ),
+                # launch.actions.ExecuteProcess(
+                #     cmd=['docker', 'restart', 'talker']
+                # ),
             ],
         )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
+
 import launch
 from launch import LaunchDescription
 from launch.actions import EmitEvent
@@ -94,7 +96,8 @@ def generate_launch_description():
                 # Log
                 LogInfo( msg = "Launch was asked to shutdown." ),
                 # Clean up docker
-                launch.actions.ExecuteProcess( cmd=docker_stop_cmd ),
+                #launch.actions.ExecuteProcess( cmd=docker_stop_cmd ),
+                subprocess.call( docker_stop_cmd ),
             ],
         )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import subprocess
+import time
 
 import launch
 from launch import LaunchDescription
@@ -40,6 +41,7 @@ def docker_stop(context, *args, **kwargs):
 def docker_restart(context, *args, **kwargs):
     docker_stop(None)
     docker_run(None)
+    time.sleep(3)
 
 
 def generate_launch_description():

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -41,7 +41,6 @@ def docker_stop(context, *args, **kwargs):
 def docker_restart(context, *args, **kwargs):
     docker_stop(None)
     docker_run(None)
-    time.sleep(3)
 
 
 def generate_launch_description():

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -51,9 +51,6 @@ def generate_launch_description():
     # Launch Description
     ld = launch.LaunchDescription()
 
-    # Shutdown event
-    #shutdown_event = EmitEvent( event = launch.events.Shutdown() )
-
     # Watchdog node
     watchdog_node = LifecycleNode(
         package='sw_watchdog',

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
     # Make the Watchdog node take the 'activate' transition
     watchdog_activate_trans_event = EmitEvent(
         event = ChangeState(
-            lifecycle_node_matcher = launch.events.process.matches_action(watchdog_node),
+            lifecycle_node_matcher = launch.events.matches_action(watchdog_node),
             transition_id = lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
          )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -41,16 +41,12 @@ def docker_restart(context, *args, **kwargs):
     docker_stop(None)
     docker_run(None)
 
+
 def generate_launch_description():
     set_tty_launch_config_action = launch.actions.SetLaunchConfiguration("emulate_tty", "True")
 
     # Launch Description
     ld = launch.LaunchDescription()
-
-    # docker_run_cmd = launch.actions.ExecuteProcess(
-    #     cmd=['docker', 'run', '-d', '--rm', '--name', 'talker', '-v', '/var/run/docker.sock:/var/run/docker.sock', '-v', '/usr/bin/docker:/usr/bin/docker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'],
-    #     #output='screen'
-    # )
 
     # Shutdown event
     #shutdown_event = EmitEvent( event = launch.events.Shutdown() )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -31,7 +31,7 @@ import lifecycle_msgs.msg
 
 # Start monitored entity
 def docker_run(context, *args, **kwargs):
-    subprocess.call(['docker', 'run', '-d', '--rm', '--name', 'talker', '-v', '/var/run/docker.sock:/var/run/docker.sock', '-v', '/usr/bin/docker:/usr/bin/docker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'])
+    subprocess.call(['docker', 'run', '-d', '--rm', '--name', 'talker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'])
 
 # Stop docker container
 def docker_stop(context, *args, **kwargs):
@@ -40,7 +40,6 @@ def docker_stop(context, *args, **kwargs):
 # Restart docker container
 def docker_restart(context, *args, **kwargs):
     docker_stop(None)
-    time.sleep(1)
     docker_run(None)
 
 

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2020 Mapless AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+from launch import LaunchDescription
+from launch.actions import EmitEvent
+from launch.actions import LogInfo
+from launch.actions import RegisterEventHandler
+from launch_ros.actions import Node
+from launch_ros.actions import LifecycleNode
+from launch_ros.events.lifecycle import ChangeState
+from launch_ros.event_handlers import OnStateTransition
+
+import lifecycle_msgs.msg
+
+def generate_launch_description():
+    set_tty_launch_config_action = launch.actions.SetLaunchConfiguration("emulate_tty", "True")
+
+    # Launch Description
+    ld = launch.LaunchDescription()
+
+    # Start monitored entity once (via docker)
+    docker_run_cmd = launch.actions.ExecuteProcess(
+        cmd=['docker', 'run', '-d', '--name', 'talker', '-v', '/var/run/docker.sock:/var/run/docker.sock', '-v', '/usr/bin/docker:/usr/bin/docker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'],
+        #output='screen'
+    )
+
+    # Restart monitored entity upon watchdog miss (via docker)
+    docker_restart_cmd = launch.actions.ExecuteProcess(
+        cmd=['docker', 'restart', 'talker']
+        #output='screen'
+    )
+
+    # Remove docker container
+    docker_rm_cmd = launch.actions.ExecuteProcess(
+        cmd=['docker', 'rm', 'talker']
+        #output='screen'
+    )
+
+    # Shutdown event
+    #shutdown_event = EmitEvent( event = launch.events.Shutdown() )
+
+    # Watchdog node
+    watchdog_node = LifecycleNode(
+        package='sw_watchdog',
+        node_executable='simple_watchdog',
+        node_namespace='',
+        node_name='simple_watchdog',
+        output='screen',
+        arguments=['220', '--publish', '--activate']
+        #arguments=['__log_level:=debug']
+    )
+
+    # Make the Watchdog node take the 'activate' transition
+    watchdog_activate_trans_event = EmitEvent(
+        event = ChangeState(
+            lifecycle_node_matcher = launch.events.process.matches_action(watchdog_node),
+            transition_id = lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
+         )
+    )
+
+    # When the watchdog reaches the 'inactive' state, log a message
+    # and restart monitored entity (via docker)
+    watchdog_inactive_handler = RegisterEventHandler(
+        OnStateTransition(
+            target_lifecycle_node = watchdog_node,
+            goal_state = 'inactive',
+            entities = [
+                # Log
+                LogInfo( msg = "Watchdog transitioned to 'INACTIVE' state." ),
+                # Change state event (inactive -> active)
+                watchdog_activate_trans_event,
+                # Restart the monitored entity
+                docker_restart_cmd,
+            ],
+        )
+    )
+
+    # When the Watchdog node reaches the 'finalized' state, clean up docker
+    watchdog_finalized_state_handler = RegisterEventHandler(
+        OnStateTransition(
+            target_lifecycle_node = watchdog_node,
+            goal_state = 'finalized',
+            entities = [
+                # Log
+                LogInfo( msg = "Watchdog transitioned to 'FINALIZED' state." ),
+                # Clean up docker
+                docker_rm_cmd,
+                #shutdown_event,
+            ],
+        )
+    )
+
+    # Add the actions to the launch description.
+    # The order they are added reflects the order in which they will be executed
+    ld.add_action( set_tty_launch_config_action )
+    ld.add_action( docker_run_cmd )
+    ld.add_action( watchdog_node )
+    ld.add_action( watchdog_inactive_handler )
+    ld.add_action( watchdog_finalized_state_handler )
+
+    return ld

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -33,15 +33,15 @@ def generate_launch_description():
 
     # Start monitored entity once (via docker)
     docker_run_cmd = launch.actions.ExecuteProcess(
-        cmd=['docker', 'run', '-d', '--name', 'talker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'],
+        cmd=['docker', 'run', '-d', '--name', 'talker', '-v', '/var/run/docker.sock:/var/run/docker.sock', '-v', '/usr/bin/docker:/usr/bin/docker', 'sw_watchdogs:latest', 'ros2', 'launch', 'sw_watchdog', 'heartbeat_composition.launch.py'],
         #output='screen'
     )
 
     # Restart monitored entity upon watchdog miss (via docker)
-    docker_restart_cmd = launch.actions.ExecuteProcess(
-        cmd=['docker', 'restart', 'talker']
-        #output='screen'
-    )
+    # docker_restart_cmd = launch.actions.ExecuteProcess(
+    #     cmd=['docker', 'restart', 'talker']
+    #     #output='screen'
+    # )
 
     # Remove docker container
     docker_rm_cmd = launch.actions.ExecuteProcess(
@@ -84,7 +84,9 @@ def generate_launch_description():
                 # Change state event (inactive -> active)
                 watchdog_activate_trans_event,
                 # Restart the monitored entity
-                docker_restart_cmd,
+                launch.actions.ExecuteProcess(
+                    cmd=['docker', 'restart', 'talker']
+                ),
             ],
         )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -21,7 +21,7 @@ from launch_ros.actions import Node
 from launch_ros.actions import LifecycleNode
 from launch_ros.events.lifecycle import ChangeState
 from launch_ros.event_handlers import OnStateTransition
-from launch_ros.event_handlers import OnShutdown
+from launch.event_handlers.on_shutdown import OnShutdown
 
 import lifecycle_msgs.msg
 

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -36,6 +36,10 @@ def docker_run(context, *args, **kwargs):
 def docker_stop(context, *args, **kwargs):
     subprocess.call(['docker', 'stop', 'talker'])
 
+# Restart docker container
+def docker_restart(context, *args, **kwargs):
+    docker_stop(None)
+    docker_run(None)
 
 def generate_launch_description():
     set_tty_launch_config_action = launch.actions.SetLaunchConfiguration("emulate_tty", "True")
@@ -83,9 +87,7 @@ def generate_launch_description():
                 # Change state event (inactive -> active)
                 watchdog_activate_trans_event,
                 # Restart the monitored entity
-                # Wait for stop command to return before docker run command
-                OpaqueFunction(function=docker_stop),
-                OpaqueFunction(function=docker_run),
+                OpaqueFunction(function=docker_restart),
             ],
         )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -84,10 +84,10 @@ def generate_launch_description():
             entities = [
                 # Log
                 LogInfo( msg = "Watchdog transitioned to 'INACTIVE' state." ),
-                # Change state event (inactive -> active)
-                watchdog_activate_trans_event,
                 # Restart the monitored entity
                 OpaqueFunction(function=docker_restart),
+                # Change state event (inactive -> active)
+                watchdog_activate_trans_event,
             ],
         )
     )

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -41,7 +41,7 @@ def docker_stop(context, *args, **kwargs):
 # Restart docker container
 def docker_restart(context, *args, **kwargs):
     docker_stop(None)
-    time.wait(1)
+    time.sleep(1)
     docker_run(None)
 
 

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
 
     # Remove docker container
     docker_rm_cmd = launch.actions.ExecuteProcess(
-        cmd=['docker', 'rm', 'talker']
+        cmd=['docker', 'rm', '-f', 'talker']
         #output='screen'
     )
 

--- a/launch/watchdog_in_docker.launch.py
+++ b/launch/watchdog_in_docker.launch.py
@@ -77,8 +77,12 @@ def generate_launch_description():
                 # Change state event (inactive -> active)
                 watchdog_activate_trans_event,
                 # Restart the monitored entity
-                launch.actions.ExecuteProcess( cmd=docker_stop_cmd ),
-                launch.actions.ExecuteProcess( cmd=docker_run_cmd ),
+                # Wait for stop command to return before docker run command
+                launch.actions.ExecuteProcess( cmd=docker_stop_cmd,
+                                               on_exit=[
+                                                   launch.actions.ExecuteProcess( cmd=docker_run_cmd ),
+                                               ]
+                ),
             ],
         )
     )

--- a/src/simple_watchdog.cpp
+++ b/src/simple_watchdog.cpp
@@ -162,7 +162,7 @@ public:
                     RCLCPP_INFO(get_logger(), "Watchdog raised, heartbeat sent at [%d.x]", msg->stamp.sec);
                 },
                 heartbeat_sub_options_);
-            RCLCPP_INFO(get_logger(), "New sub: %s", heartbeat_sub_->get_name());
+            RCLCPP_INFO(get_logger(), "New sub: %s", heartbeat_sub_->get_topic_name());
         }
 
         // Starting from this point, all messages are sent to the network.

--- a/src/simple_watchdog.cpp
+++ b/src/simple_watchdog.cpp
@@ -162,7 +162,6 @@ public:
                     RCLCPP_INFO(get_logger(), "Watchdog raised, heartbeat sent at [%d.x]", msg->stamp.sec);
                 },
                 heartbeat_sub_options_);
-            RCLCPP_INFO(get_logger(), "New sub: %s", heartbeat_sub_->get_topic_name());
         }
 
         // Starting from this point, all messages are sent to the network.

--- a/src/simple_watchdog.cpp
+++ b/src/simple_watchdog.cpp
@@ -162,6 +162,7 @@ public:
                     RCLCPP_INFO(get_logger(), "Watchdog raised, heartbeat sent at [%d.x]", msg->stamp.sec);
                 },
                 heartbeat_sub_options_);
+            RCLCPP_INFO(get_logger(), "New sub: %s", heartbeat_sub_->get_name());
         }
 
         // Starting from this point, all messages are sent to the network.


### PR DESCRIPTION
This introduces the _"dockerized"_ watchdog and monitored process example introduced in the Autoware workshop at IV 2020. 

![dockerized](https://user-images.githubusercontent.com/478855/96934900-0adcfb80-1491-11eb-9c55-8aa93767bacf.jpg)

The choice of Docker for this example is because it facilitates use of cgroups (kernel control groups for resource allocation and isolation), and kernel namespaces for process isolation. The monitored entity can crash or be otherwise stopped/stalled and the Watchdog will respawn the entity.

To test the functionality in this PR:
- [Install docker](https://docs.docker.com/get-docker/) for your Linux distribution
- Check out this branch and edit the included Dockerfile as follows:
```
diff --git a/Dockerfile b/Dockerfile
index d6fa9fd..c3b79af 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL stage=intermediate
 
 # Clone and build repository
 WORKDIR /root
-RUN git clone https://github.com/ros-safety/software_watchdogs.git
+RUN git clone -b experimental-relaunch https://github.com/ros-safety/software_watchdogs.git
 RUN . /opt/ros/foxy/setup.sh && \
     colcon build
```
This will make sure that the correct branch is used in the next step (as long as this PR is not merged to master yet).
- Build the Docker image:
```
docker build --no-cache . -t sw_watchdogs:latest
```
- Run the demo (`watchdog_in_docker.launch.py`) via:
```
docker run -it --rm --name testing -v /var/run/docker.sock:/var/run/docker.sock \
-v /usr/bin/docker:/usr/bin/docker sw_watchdogs:latest ros2 launch sw_watchdog watchdog_in_docker.launch.py
```
This command brings up both the watchdog and the monitored application in two separate containers. See `watchdog_in_docker.launch.py` for details. Expect terminal output as follows after startup:

<img src="https://user-images.githubusercontent.com/478855/96937031-424da700-1495-11eb-967e-78862be881a7.jpg" alt="terminal" width="75%" height="75%">

- Manually interfere with the monitored application, for example via: 
```
docker kill --signal=SIGINT talker
```
This will kill the monitored entity (called `talker`) and force the watchdog to restart it shortly after. In the original terminal, this restart activity will be reflected as follows:

<img src="https://user-images.githubusercontent.com/478855/96937283-c869ed80-1495-11eb-952a-97b0491d2f9a.jpg" alt="terminal-2" width="75%" height="75%">
