### PR TITLE
Adding default to the parameter so that it compiles in Humble

### DIFF
--- a/sw_watchdog/src/simple_heartbeat.cpp
+++ b/sw_watchdog/src/simple_heartbeat.cpp
@@ -55,7 +55,7 @@ public:
         : Node("simple_heartbeat", options.start_parameter_event_publisher(false).
                                            start_parameter_services(false))
     {
-        declare_parameter("period");
+        declare_parameter("period", 100);
 
         const std::vector<std::string>& args = this->get_node_options().arguments();
         // Parse node arguments


### PR DESCRIPTION
Adding a default to the parameter so that this compiles in Humble. 

Resolves https://github.com/ros-safety/software_watchdogs/issues/13
